### PR TITLE
Embed commit SHA in Docker image

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -36,6 +36,8 @@ jobs:
         tags: |
           turan919/medusajs-demo:latest
           turan919/medusajs-demo:${{ github.sha }}
+        build-args: |
+          COMMIT_SHA=${{ github.sha }}
     
     - name: Update K8s deployment image
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM nginx:alpine
 
+ARG COMMIT_SHA
+
 # Custom nginx config
 COPY k8s-manifests/nginx-config.conf /etc/nginx/conf.d/default.conf
 
 # Create directory and add custom HTML content
 RUN mkdir -p /usr/share/nginx/html && \
-    echo '<h1>🚀 MedusaJS CI/CD Demo</h1><p>Deployed via GitHub Actions!</p><p>Commit: $COMMIT_SHA</p>' > /usr/share/nginx/html/index.html
+    echo "<h1>🚀 MedusaJS CI/CD Demo</h1><p>Deployed via GitHub Actions!</p><p>Commit: ${COMMIT_SHA}</p>" > /usr/share/nginx/html/index.html
 
 EXPOSE 80


### PR DESCRIPTION
## Summary
- use COMMIT_SHA build arg in Dockerfile
- pass github.sha build arg in staging workflow

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857f50855e48331a6de69ef13ec101b